### PR TITLE
Feat: Log to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ TeeTimeFinder -d 17-08-2024 -t 09:00 -s 2 -c "Royal Perth Golf Club" -c "Royal F
 
 ### Commands and Flags
 Main Commands
-| Flag          | Description                          | Example       |
-|---------------|--------------------------------------|---------------|
-| -d, --date    | Search date (DD-MM-YYYY)             | -d 24-06-2025 |
-| -t, --time    | Centre time for 2hr window (±1 hour) | -t 14:30      |
-| -s, --spots   | Minimum available player spots (1-4) | -s 3          |
-| -c, --courses | Specify particular courses to search | -c "Course"   |
-| -v, --verbose | Enable verbose debug output          |               |
+| Flag          | Description                                                            | Example       |
+|---------------|------------------------------------------------------------------------|---------------|
+| -d, --date    | Search date (DD-MM-YYYY)                                               | -d 24-06-2025 |
+| -t, --time    | Centre time for 2hr window (±1 hour)                                   | -t 14:30      |
+| -s, --spots   | Minimum available player spots (1-4)                                   | -s 3          |
+| -c, --courses | Specify particular courses to search                                   | -c "Course"   |
+| -v, --verbose | Enable verbose debug output (debug.log file found in config directory) |               |
 
 Configuration Commands
 

--- a/cmd/logging.go
+++ b/cmd/logging.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// setupLogging turns on Bubble Tea’s file logger when the –v/--verbose flag
+// is present.  It returns the opened *os.File so main() can defer Close().
+func setupLogging() (*os.File, error) {
+	if !verboseMode { // flag not set keep stdout clean
+		return nil, nil
+	}
+
+	// ~/.config/TeeTimeFinder/debug.log  (mkdir -p if necessary)
+	cfgDir, err := os.UserConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	logDir := filepath.Join(cfgDir, "TeeTimeFinder")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return nil, err
+	}
+	logPath := filepath.Join(logDir, "debug.log")
+
+	// Write “TeeTimeFinder ” in front of every line
+	return tea.LogToFile(logPath, "TeeTimeFinder")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&specifiedDate, "date", "d", "", "Specify the date for the tee time search (format: DD-MM-YYYY)")
 	rootCmd.PersistentFlags().IntVarP(&specifiedSpots, "spots", "s", 0, "Filter timeslots based on available player spots (1-4)")
 	rootCmd.PersistentFlags().StringArrayVarP(&courseList, "courses", "c", nil, "Specify particular courses to search")
-	rootCmd.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable verbose debug output")
+	rootCmd.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable verbose debug output (Creates  debug.log file found in your config directory)")
 
 	// Initalise logging for -verbose flag
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&specifiedDate, "date", "d", "", "Specify the date for the tee time search (format: DD-MM-YYYY)")
 	rootCmd.PersistentFlags().IntVarP(&specifiedSpots, "spots", "s", 0, "Filter timeslots based on available player spots (1-4)")
 	rootCmd.PersistentFlags().StringArrayVarP(&courseList, "courses", "c", nil, "Specify particular courses to search")
-	rootCmd.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable verbose debug output (Creates  debug.log file found in your config directory)")
+	rootCmd.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable verbose debug output (Creates debug.log file found in your config directory)")
 
 	// Initalise logging for -verbose flag
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"TeeTimeFinder/pkg/shared"
 	"bufio"
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 	"sort"
@@ -62,6 +63,8 @@ var nineHoleRegex = regexp.MustCompile(`\b9\s*hole(s)?\b`)
 var eighteenHoleRegex = regexp.MustCompile(`\b18\s*hole(s)?\b`)
 var reSpaceAMPMRegex = regexp.MustCompile(`(\d+:\d+)(AM|PM)\b`)
 
+var logFile *os.File
+
 var rootCmd = &cobra.Command{
 	Use:   "TeeTimeFinder",
 	Short: "A CLI tool for finding golf tee times",
@@ -86,6 +89,22 @@ func init() {
 	rootCmd.PersistentFlags().StringArrayVarP(&courseList, "courses", "c", nil, "Specify particular courses to search")
 	rootCmd.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable verbose debug output")
 
+	// Initalise logging for -verbose flag
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		f, err := setupLogging()
+		if err != nil {
+			return err
+		}
+		logFile = f
+		return nil
+	}
+
+	rootCmd.PersistentPostRun = func(cmd *cobra.Command, _ []string) {
+		if logFile != nil {
+			_ = logFile.Close()
+		}
+	}
+
 	// Register the completion function here
 	rootCmd.RegisterFlagCompletionFunc("courses", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		// Load courses from config
@@ -109,13 +128,13 @@ func init() {
 // Debug print functions that only print if verboseMode is true
 func debugPrintln(a ...interface{}) {
 	if verboseMode {
-		fmt.Println("DEBUG:", fmt.Sprint(a...))
+		log.Println(a...)
 	}
 }
 
 func debugPrintf(format string, a ...interface{}) {
 	if verboseMode {
-		fmt.Printf("DEBUG: "+format, a...)
+		log.Printf(format, a...)
 	}
 }
 


### PR DESCRIPTION
Changed `--verbose` logs to output to `debug.log` file in config directory. Because bubbletea takes up tui, user is not able to view logs in terminal. Instead they are output to a file. 